### PR TITLE
Ignore irregular lines in the lineages.csv file

### DIFF
--- a/covizu/treetime.py
+++ b/covizu/treetime.py
@@ -287,8 +287,14 @@ if __name__ == '__main__':
         sys.exit()
     lineages = {}
     for line in handle:
-        taxon, lineage = line.strip().split(',')
-        lineages.update({taxon: lineage})
+        try:
+            taxon, lineage = line.strip().split(',')
+            if taxon and lineage:
+                lineages.update({taxon: lineage})
+            else:
+                cb.callback("Warning '{}': taxon or lineage is missing".format(line), level='WARN')
+        except:
+            cb.callback("Warning: There is an issue with the line '{}' in lineages.csv".format(line), level='WARN')
 
     cb.callback("Identifying lineage representative genomes")
     fasta = retrieve_genomes(by_lineage, known_seqs=lineages, ref_file=args.ref, earliest=args.earliest,

--- a/covizu/utils/batch_utils.py
+++ b/covizu/utils/batch_utils.py
@@ -51,8 +51,16 @@ def build_timetree(by_lineage, args, callback=None):
         sys.exit()
     lineages = {}
     for line in handle:
-        taxon, lineage = line.strip().split(',')
-        lineages.update({taxon: lineage})
+        try:
+            taxon, lineage = line.strip().split(',')
+            if taxon and lineage:
+                lineages.update({taxon: lineage})
+            else:
+                if callback:
+                    callback("Warning '{}': taxon or lineage is missing".format(line), level='WARN')
+        except:
+            if callback:
+                callback("Warning: There is an issue with the line '{}' in lineages.csv".format(line), level='WARN')
 
     if callback:
         callback("Identifying lineage representative genomes")


### PR DESCRIPTION
Blank lines and lines that are incorrectly formatted have been causing our pipelines to crash. This fix ignores these lines from `lineages.csv` #416 